### PR TITLE
Fix: Add rate limiting to authentication routes

### DIFF
--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -2,21 +2,23 @@ const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/authController'); // Or wherever your controller is
 const authMiddleware = require('../middleware/authMiddleware'); // A middleware to verify JWT
+const rateLimit = require('express-rate-limit');
+
+// Apply a general rate limiter to all requests in this router
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // Limit each IP to 20 requests per window
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  message: 'Too many requests from this IP, please try again after 15 minutes',
+});
+
+router.use(authLimiter);
 
 // Existing Google login route
 router.post('/google', authController.googleLogin);
 
-const rateLimit = require('express-rate-limit');
-
-// Rate limiting middleware for protected routes
-const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // Limit each IP to 100 requests per window
-  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-});
-
-// NEW: Protected route to get user profile (with rate limiting)
-router.get('/me', apiLimiter, authMiddleware, authController.getMe);
+// Protected route to get user profile
+router.get('/me', authMiddleware, authController.getMe);
 
 module.exports = router;


### PR DESCRIPTION
This commit introduces rate limiting to all authentication-related routes in `server/routes/authRoutes.js` to mitigate the risk of brute-force and denial-of-service attacks.

The `express-rate-limit` middleware is used to apply a general rate limit of 20 requests per IP every 15 minutes to all endpoints handled by the authentication router. This addresses the "Missing rate limiting" vulnerabilities detected by CodeQL.